### PR TITLE
#210 : fix action failing when no unit tests are provided

### DIFF
--- a/.github/workflows/ci-build-next-java.yml
+++ b/.github/workflows/ci-build-next-java.yml
@@ -35,3 +35,4 @@ jobs:
         if: ${{ always() && github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]' }}
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          fail_if_no_tests: false

--- a/src/main/resources/templates/default/require_exact/.github/workflows/ci-build-next-java.yml
+++ b/src/main/resources/templates/default/require_exact/.github/workflows/ci-build-next-java.yml
@@ -35,3 +35,4 @@ jobs:
         if: ${{ always() && github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]' }}
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          fail_if_no_tests: false


### PR DESCRIPTION
Fixes #210  surefire action report failing when there are no unit tests in the project (in workflow ci-build-next-java)